### PR TITLE
Hotfixes

### DIFF
--- a/app/models/catarse_pagarme/payment_delegator.rb
+++ b/app/models/catarse_pagarme/payment_delegator.rb
@@ -69,6 +69,8 @@ module CatarsePagarme
     end
 
     def transaction
+      raise "no gateway_id present" unless self.payment.gateway_id.present?
+
       @transaction ||= ::PagarMe::Transaction.find_by_id(self.payment.gateway_id)
       if @transaction.kind_of?(Array)
         @transaction.last

--- a/app/models/catarse_pagarme/payment_delegator.rb
+++ b/app/models/catarse_pagarme/payment_delegator.rb
@@ -69,14 +69,15 @@ module CatarsePagarme
     end
 
     def transaction
-      raise "no gateway_id present" unless self.payment.gateway_id.present?
+      gateway_id = self.payment.gateway_id
+      raise "no gateway_id present" unless gateway_id.present?
 
-      @transaction ||= ::PagarMe::Transaction.find_by_id(self.payment.gateway_id)
-      if @transaction.kind_of?(Array)
-        @transaction.last
-      else
-        @transaction
-      end
+      @transaction ||= ::PagarMe::Transaction.find_by_id(gateway_id)
+      _transaction = @transaction.kind_of?(Array) ? @transaction.last : @transaction
+
+      raise "transaction gateway not match" unless _transaction.id == gateway_id
+
+      _transaction
     end
 
     def get_installment(installment_number)

--- a/spec/controllers/catarse_pagarme/notifications_controller_spec.rb
+++ b/spec/controllers/catarse_pagarme/notifications_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe CatarsePagarme::NotificationsController do
-  let(:fake_transaction) { double("fake transaction", card_brand: 'visa', acquirer_name: 'stone', tid: '404040404', installments: 2) }
+  let(:fake_transaction) { double("fake transaction", id: payment.gateway_id, card_brand: 'visa', acquirer_name: 'stone', tid: '404040404', installments: 2) }
 
   before do
     PagarMe.stub(:validate_fingerprint).and_return(true)
@@ -10,8 +10,8 @@ describe CatarsePagarme::NotificationsController do
 
   let(:project) { create(:project, goal: 10_000, state: 'online') }
   let(:contribution) { create(:contribution, value: 10, project: project) }
-  let(:payment) { 
-    p = contribution.payments.first 
+  let(:payment) {
+    p = contribution.payments.first
     p.update_attributes gateway_id: 'abcd'
     p
   }


### PR DESCRIPTION
Check if transaction that pagarme returns is the correct transaction for payment.
This fixes the bugs when gateway_id is nil and pagarme returns a list of transactions when find_by_id receives nil arg.