### PR TITLE
✨ Adiciona taxa aos boletos de projetos pontuais.

### DIFF
--- a/app/models/catarse_pagarme/slip_transaction.rb
+++ b/app/models/catarse_pagarme/slip_transaction.rb
@@ -13,6 +13,11 @@ module CatarsePagarme
       self.transaction = PagarMe::Transaction.new(
         self.attributes.merge(payment_method: 'boleto', async: false)
       )
+
+      if ['flex' || 'aon'].include? payment.contribution.project.mode
+        self.transaction.attributes['amount'] += 200
+      end
+
       self.transaction.charge
 
       change_payment_state
@@ -22,5 +27,6 @@ module CatarsePagarme
     def payment_method
       PaymentType::SLIP
     end
+
   end
 end


### PR DESCRIPTION
**Descrição**:
Para projetos pontuais, iremos passar a cobrar o valor da emissão do boleto aos apoiadores da mesma forma que o juros de parcelamento é cobrado hoje, apenas é registrado o valor a mais no pagar.me.

**Link de referência**:
https://www.notion.so/catarse/Implementar-a-cobran-a-de-boletos-em-projetos-pontuais-12c9817875d84dcf9b91f0249e334560
